### PR TITLE
Dirty fix to avoid space under status bar

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -469,11 +469,11 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         if (!self.statusBarOverlaysWebView) {
             if (_statusBarVisible) {
                 // CB-10158 If a full screen video is playing the status bar height will be 0, set it to 20 if _statusBarVisible
-                frame.origin.y = height > 0 ? height: 20;
+//                frame.origin.y = height > 0 ? height: 20;
             }
         } else {
             // Even if overlay is used, we want to handle in-call/recording/hotspot larger status bar
-            frame.origin.y = height >= 20 ? height - 20 : 0;
+//            frame.origin.y = height >= 20 ? height - 20 : 0;
         }
         frame.size.height -= frame.origin.y;
         self.webView.frame = frame;


### PR DESCRIPTION
Dirty fix to avoid 20px height between status bar and web view

Always use:
  StatusBar.overlaysWebView(false);
  StatusBar.show();

For default style, use:
  StatusBar.styleDefault();

For black style, use:
  StatusBar.styleLightContent();
  StatusBar.backgroundColorByHexString("#131313");

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
